### PR TITLE
fix broken link in threatmodeling tab

### DIFF
--- a/tab_threatmodeling.md
+++ b/tab_threatmodeling.md
@@ -96,6 +96,6 @@ and justifies them with either sub-claims or evidence.
 
 ## Threat Modeling Tooling
 
-There is a wide variety of tools that can support threat modeling, including [OWASP Threat Dragon](https://owasp.org/www-project-threat-dragon/), [OWASP pytm](https://owasp.org/www-project-pytm/), and [OWASP Threatspec](https://owasp.org/www-project-threatspec/). 
+There is a wide variety of tools that can support threat modeling, including [OWASP Threat Dragon](https://owasp.org/www-project-threat-dragon/), [OWASP pytm](https://owasp.org/www-project-pytm/), and [OWASP Threatspec](https://threatspec.org/). 
 
 There are also a number of other tools available, both Open Source and commercial.


### PR DESCRIPTION
Threatspec does not have an OWASP project page, so fixup link to point to their website at https://threatspec.org/
There may have been plans to bring Threatspec into the OWASP project community, as an intial repo was created at https://github.com/OWASP/ThreatSpec, but this does not seem to have progressed since 2019